### PR TITLE
Add flickery popup on icon click

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -3,9 +3,3 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       sendResponse({message: "Service worker is awake! 🎉"});
   }
 );
-
-chrome.action.onClicked.addListener(() => {
-  chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-    chrome.tabs.sendMessage(tabs[0].id, {message: "shortcut"});
-  });
-});

--- a/extension/js/cs/script.js
+++ b/extension/js/cs/script.js
@@ -11,11 +11,4 @@ function createBtn() {
   btn.textContent = "Wake the extension";
   document.body.appendChild(btn);
 }
-
-chrome.runtime.onMessage.addListener((request) => {
-    if (request.message === "shortcut")
-      alert("Action shortcut or click on icon triggered");
-  }
-);
-
 createBtn();

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -1,0 +1,1 @@
+window.close();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,8 @@
       "service_worker": "js/background.js"
     },
    "action": {
-      "default_icon": "images/icon/128x128.png"
+      "default_icon": "images/icon/128x128.png",
+      "default_popup": "popup.html"
    },
    "icons": {
       "128": "images/icon/128x128.png",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Chrome extensions boilerplate popup</title>
+		<script type="text/javascript" src="js/popup.js"></script>
+	</head>
+	<body>
+	</body>
+</html>


### PR DESCRIPTION
It seems like the dead extension state is fixed when any extension page is loaded. Current PR ensures we load popup that closes itself when user click on the extension icon. Meaning after reproduction steps in the README.md, if one clicks the extension icon with current PR the service worker will start.